### PR TITLE
Line break split sentences split

### DIFF
--- a/src/jvmMain/kotlin/components/TexArea.kt
+++ b/src/jvmMain/kotlin/components/TexArea.kt
@@ -79,7 +79,7 @@ fun BoxScope.MainTextArea(modifier: Modifier, baseViewModel: BaseViewModel) {
         val index = currentHighlightWordIndex.value
         if (index < sentences.size) {
             val move =
-                (sentences[index - 1].text.length * scrollState.maxValue / textFieldValue.length)
+                (sentences[index - 1].displayText.length * scrollState.maxValue / textFieldValue.length)
             val scroll = scrollState.value + move
             if (scroll > 20) scrollState.animateScrollTo(scroll)
         }
@@ -128,7 +128,7 @@ fun BoxScope.MainTextArea(modifier: Modifier, baseViewModel: BaseViewModel) {
                                             letterSpacing = TextUnit(1f, TextUnitType.Sp),
                                         )
                                     ) {
-                                        append("${sentence.text}${sentence.delimiter}")
+                                        append("${sentence.displayText}${sentence.delimiter}")
                                     }
                                 }
                             }

--- a/src/jvmMain/kotlin/tts/TextToSpeech.kt
+++ b/src/jvmMain/kotlin/tts/TextToSpeech.kt
@@ -46,7 +46,7 @@ class TextToSpeech {
         }
         TTSModel.isGeneratingAudio = true
         val generatedAudio = TTSModel.getInstance().generate(
-            sanitizeString(textSegment.text),
+            sanitizeString(textSegment.normalizedText),
             speakerId,
             voiceSpeed
         )
@@ -107,7 +107,7 @@ class TextToSpeech {
     }
 
     fun isValidText(textSegment: TextSegment): Boolean {
-        return textSegment.text.contains(Regex("[a-zA-Z0-9]"))
+        return textSegment.normalizedText.contains(Regex("[a-zA-Z0-9]"))
     }
 
 

--- a/src/jvmMain/kotlin/utils/TextFormatation.kt
+++ b/src/jvmMain/kotlin/utils/TextFormatation.kt
@@ -12,6 +12,9 @@ fun splitSmartWithDelimiters(input: String): List<TextSegment> {
         modified = modified.replace(abbr, placeholder)
         placeholderMap[placeholder] = abbr
     }
+    
+    // Normalize line breaks: replace single newlines with spaces, preserve paragraph breaks
+    modified = modified.replace(Regex("""\n(?!\s*\n)"""), " ")
 
     // Replace dotted identifiers (e.g., org.example.Class) with temporary tokens
     val dottedIdentifierRegex = Regex("""\b(?:[a-zA-Z_][\w]*\.)+[a-zA-Z_][\w]*\b""")
@@ -27,9 +30,9 @@ fun splitSmartWithDelimiters(input: String): List<TextSegment> {
     }
 
     // Regex to match:
-    // - a dot that’s NOT part of a number or identifier: (?<!\d)\.(?!\d|\w)
-    // - newline
-    val regex = Regex("""(?<!\d)\.(?![\d\w])|(\n+)""")
+    // - a dot that's NOT part of a number or identifier: (?<!\d)\.(?!\d|\w)
+    // - multiple newlines (paragraph breaks)
+    val regex = Regex("""(?<!\d)\.(?![\d\w])|(\n\s*\n+)""")
 
     val result = mutableListOf<TextSegment>()
     var lastIndex = 0

--- a/src/jvmMain/kotlin/utils/TextFormatation.kt
+++ b/src/jvmMain/kotlin/utils/TextFormatation.kt
@@ -12,9 +12,6 @@ fun splitSmartWithDelimiters(input: String): List<TextSegment> {
         modified = modified.replace(abbr, placeholder)
         placeholderMap[placeholder] = abbr
     }
-    
-    // Normalize line breaks: replace single newlines with spaces, preserve paragraph breaks
-    modified = modified.replace(Regex("""\n(?!\s*\n)"""), " ")
 
     // Replace dotted identifiers (e.g., org.example.Class) with temporary tokens
     val dottedIdentifierRegex = Regex("""\b(?:[a-zA-Z_][\w]*\.)+[a-zA-Z_][\w]*\b""")
@@ -30,9 +27,9 @@ fun splitSmartWithDelimiters(input: String): List<TextSegment> {
     }
 
     // Regex to match:
-    // - a dot that's NOT part of a number or identifier: (?<!\d)\.(?!\d|\w)
-    // - multiple newlines (paragraph breaks)
-    val regex = Regex("""(?<!\d)\.(?![\d\w])|(\n\s*\n+)""")
+    // - a dot that’s NOT part of a number or identifier: (?<!\d)\.(?!\d|\w)
+    // - newline
+    val regex = Regex("""(?<!\d)\.(?![\d\w])|(\n+)""")
 
     val result = mutableListOf<TextSegment>()
     var lastIndex = 0

--- a/src/jvmMain/kotlin/utils/TextFormatation.kt
+++ b/src/jvmMain/kotlin/utils/TextFormatation.kt
@@ -13,6 +13,9 @@ fun splitSmartWithDelimiters(input: String): List<TextSegment> {
         placeholderMap[placeholder] = abbr
     }
 
+    // Normalize line breaks: replace single newlines with spaces, preserve paragraph breaks
+    modified = modified.replace(Regex("""\n(?!\s*\n)"""), " ")
+
     // Replace dotted identifiers (e.g., org.example.Class) with temporary tokens
     val dottedIdentifierRegex = Regex("""\b(?:[a-zA-Z_][\w]*\.)+[a-zA-Z_][\w]*\b""")
     val dottedMap = mutableMapOf<String, String>()
@@ -27,9 +30,9 @@ fun splitSmartWithDelimiters(input: String): List<TextSegment> {
     }
 
     // Regex to match:
-    // - a dot that’s NOT part of a number or identifier: (?<!\d)\.(?!\d|\w)
-    // - newline
-    val regex = Regex("""(?<!\d)\.(?![\d\w])|(\n+)""")
+    // - a dot that's NOT part of a number or identifier: (?<!\d)\.(?!\d|\w)
+    // - multiple newlines (paragraph breaks)
+    val regex = Regex("""(?<!\d)\.(?![\d\w])|(\n\s*\n+)""")
 
     val result = mutableListOf<TextSegment>()
     var lastIndex = 0


### PR DESCRIPTION
Fixes #3,
#4  was opened after i accidentally pushed a commit to main and then reverted it.

Summary

This PR improves text formatting by properly handling line breaks in the sentence splitting logic. The fix
prevents single line breaks from incorrectly breaking sentences while preserving paragraph breaks (double
newlines).

Changes

    Modified splitSmartWithDelimiters() in TextFormatation.kt to normalize line breaks
    Single newlines (\n) are now replaced with spaces to keep sentences intact
    Paragraph breaks (multiple consecutive newlines) are preserved for proper text structure

Technical Details

Added regex pattern \n(?!\s*\n) to replace single newlines with spaces, ensuring that:

    Sentences broken across lines are properly joined
    Paragraph breaks (double newlines) remain intact for natural text flow
    TTS reads text more naturally without awkward pauses mid-sentence